### PR TITLE
chore: removed unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/handlebars": "4.1.0",
     "@types/inquirer": "9.0.7",
     "@types/node": "20.14.5",
-    "tailwindcss": "3.4.4",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   },


### PR DESCRIPTION
Removed tailwind from the list of dependencies as it is unused.